### PR TITLE
Support options to skip resize and optimize

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,11 @@ file size, and it's not noticeable unless you look hard. You can see in the
 example code above that we compress everything but the header images using a
 lossy compression.
 
+There are also two options called `skipResize` and `skipOptimize` that you want
+to set true only on the certain situation. For example, they would be useful when
+you run integration tests on CI. It skips resizing but copies images with the
+publishing names. Both are false in default.
+
 ### scss*
 
 The scss tasks runs compass on one or more specified SCSS files, then runs

--- a/tasks/responsive-images.js
+++ b/tasks/responsive-images.js
@@ -16,7 +16,7 @@ module.exports = function (gulp, plugins, options) {
       .pipe(plugins.plumber({ errorHandler: options.onError }))
       .pipe(handleRename('-xlarge'))
       .pipe(handleChanged())
-      .pipe(handleOptimize())
+      .pipe(plugins.if(!options.skipOptimize, handleOptimize()))
       .pipe(gulp.dest(options.dest));
 
     imageTasks.push(stream);
@@ -26,10 +26,10 @@ module.exports = function (gulp, plugins, options) {
     // Deal with each size separately
     _.each(sizes, function (factor, suffix) {
       var stream = images.pipe(plugins.clone())
-        .pipe(handleResize(factor))
+        .pipe(plugins.if(!options.skipResize, handleResize(factor)))
         .pipe(handleRename('-' + suffix))
         .pipe(handleChanged())
-        .pipe(handleOptimize())
+        .pipe(plugins.if(!options.skipOptimize, handleOptimize()))
         .pipe(gulp.dest(options.dest));
 
       imageTasks.push(stream);


### PR DESCRIPTION
Support options to skip resize and optimize. You may want to skip those steps on CI environment to speed up tests.
