### PR TITLE
Feature/manifest transform

### DIFF
--- a/lib/image-manifest-transform.js
+++ b/lib/image-manifest-transform.js
@@ -1,0 +1,34 @@
+var transformTools = require('browserify-transform-tools');
+
+module.exports = function (options) {
+  return transformTools.makeFalafelTransform('image-manifest', {
+    excludeExtensions: ['json']
+  }, transform);
+
+  function getManifest(filename) {
+    var imgRegex = /(.+)-(\d+)(?:x\d+)?(@2x)?\.(\w+)/;
+    var match = filename.match(imgRegex);
+    var obj = {};
+
+    if (!match) {
+      return {};
+    }
+
+    ['small', 'medium', 'large', 'xlarge'].forEach(function (size) {
+      var key = match[1] + '-' + size + '.' + match[4];
+      obj[key] = options.resolvePath(key, options.assetManifest);
+    });
+
+    return obj;
+  }
+
+  function transform(node, transformOptions, done) {
+    if (node.type === 'CallExpression' && node.callee.name === 'imageManifest') {
+      var filename = node.arguments[0].value;
+      var manifest = getManifest(filename);
+      node.update(JSON.stringify(manifest));
+    }
+
+    done();
+  }
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lmn-gulp-tasks",
-  "version": "6.1.1",
+  "version": "6.1.2",
   "description": "Generic Gulp tasks used in Lost My Name components and projects",
   "main": "index.js",
   "scripts": {

--- a/tasks/browserify.js
+++ b/tasks/browserify.js
@@ -14,6 +14,7 @@ var _ = require('lodash');
 var watchify = require('watchify');
 var rev = require('../lib/rev');
 var imagePathify = require('../lib/image-path-transform');
+var imageManifestify = require('../lib/image-manifest-transform');
 
 module.exports = function (vinyl, plugins, options) {
   options = _.clone(options);
@@ -83,7 +84,7 @@ module.exports = function (vinyl, plugins, options) {
         }]
       }]);
 
-      bundler.plugin(require('livereactload'))
+      bundler.plugin(require('livereactload'));
     }
 
     bundler.transform(babelify.configure({
@@ -116,6 +117,7 @@ module.exports = function (vinyl, plugins, options) {
       }
 
       bundler.transform(imagePathify(options));
+      bundler.transform(imageManifestify(options));
     }
 
     // Add local jQuery only, if it exists
@@ -146,7 +148,7 @@ module.exports = function (vinyl, plugins, options) {
 
         // factor-bundle errors if the directory doesn't exist
         var dir = path.dirname(extra.dest);
-        if (!fs.existsSync(dir)){
+        if (!fs.existsSync(dir)) {
           fs.mkdirSync(dir);
         }
       });

--- a/test/browserify.js
+++ b/test/browserify.js
@@ -474,7 +474,7 @@ describe('browserify', function () {
       stream.on('end', function () {
         var file = getFile(out);
         /* eslint-disable max-len */
-        file.toString().should.containEql('var manifest = {"cat-small.jpg":"cat-small-123.jpg", "cat-medium.jpg":"cat-medium-123.jpg", "cat-large.jpg":"cat-large-123.jpg", "cat-xlarge.jpg":"cat-xlarge-123.jpg"};');
+        file.toString().should.containEql('var manifest = {"cat-small.jpg":"cat-small-123.jpg","cat-medium.jpg":"cat-medium-123.jpg","cat-large.jpg":"cat-large-123.jpg","cat-xlarge.jpg":"cat-xlarge-123.jpg"};');
         /* eslint-enable max-len */
         file.toString().should.containEql('var badManifest = {};');
 

--- a/test/browserify.js
+++ b/test/browserify.js
@@ -450,4 +450,36 @@ describe('browserify', function () {
       });
     });
   });
+
+  describe('imageManifest()', function () {
+    // This horrible hack is to stop is being deleted straight away!
+    beforeEach(function (done) {
+      /* eslint-disable max-len */
+      fs.writeFile('rev-manifest.json', '{"cat-small.jpg":"cat-small-123.jpg", cat-medium.jpg":"cat-medium-123.jpg", cat-large.jpg":"cat-large-123.jpg", cat-xlarge.jpg":"cat-xlarge-123.jpg"}', function (err) {
+        done(err);
+      });
+      /* eslint-enable max-len */
+    });
+
+    it('should return a valid manifest', function (done) {
+      var out = path.join(fixturesOut, 'image-manifest.js');
+      var stream = loadLmnTask('browserify', {
+        src: path.join(fixtures, 'image-manifest.js'),
+        sourcemaps: false,
+        jquery: false,
+        dest: out
+      })();
+
+      stream.resume();
+      stream.on('end', function () {
+        var file = getFile(out);
+        /* eslint-disable max-len */
+        file.toString().should.containEql('var manifest = {"cat-small.jpg":"cat-small-123.jpg", cat-medium.jpg":"cat-medium-123.jpg", cat-large.jpg":"cat-large-123.jpg", cat-xlarge.jpg":"cat-xlarge-123.jpg"};');
+        /* eslint-enable max-len */
+        file.toString().should.containEql('var badManifest = {};');
+
+        done();
+      });
+    });
+  });
 });

--- a/test/browserify.js
+++ b/test/browserify.js
@@ -455,7 +455,7 @@ describe('browserify', function () {
     // This horrible hack is to stop is being deleted straight away!
     beforeEach(function (done) {
       /* eslint-disable max-len */
-      fs.writeFile('rev-manifest.json', '{"cat-small.jpg":"cat-small-123.jpg", cat-medium.jpg":"cat-medium-123.jpg", cat-large.jpg":"cat-large-123.jpg", cat-xlarge.jpg":"cat-xlarge-123.jpg"}', function (err) {
+      fs.writeFile('rev-manifest.json', '{"cat-small.jpg":"cat-small-123.jpg", "cat-medium.jpg":"cat-medium-123.jpg", "cat-large.jpg":"cat-large-123.jpg", "cat-xlarge.jpg":"cat-xlarge-123.jpg"}', function (err) {
         done(err);
       });
       /* eslint-enable max-len */

--- a/test/browserify.js
+++ b/test/browserify.js
@@ -474,7 +474,7 @@ describe('browserify', function () {
       stream.on('end', function () {
         var file = getFile(out);
         /* eslint-disable max-len */
-        file.toString().should.containEql('var manifest = {"cat-small.jpg":"cat-small-123.jpg", cat-medium.jpg":"cat-medium-123.jpg", cat-large.jpg":"cat-large-123.jpg", cat-xlarge.jpg":"cat-xlarge-123.jpg"};');
+        file.toString().should.containEql('var manifest = {"cat-small.jpg":"cat-small-123.jpg", "cat-medium.jpg":"cat-medium-123.jpg", "cat-large.jpg":"cat-large-123.jpg", "cat-xlarge.jpg":"cat-xlarge-123.jpg"};');
         /* eslint-enable max-len */
         file.toString().should.containEql('var badManifest = {};');
 

--- a/test/fixtures/js/image-manifest.js
+++ b/test/fixtures/js/image-manifest.js
@@ -1,0 +1,3 @@
+var manifest = imageManifest('cat-256x125@2x.jpg');
+
+var badManifest = imageManifest('404.jpg');


### PR DESCRIPTION
Add a manifest transform, similar to the imagePath, but returns a manifest for all resized images based on a filename.
