### PR TITLE
Fix max-props-per-line declaration

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -95,7 +95,7 @@
     "react/jsx-indent-props": [2, 2],
     "react/jsx-indent": [2, 2],
     "react/jsx-key": 2,
-    "react/jsx-max-props-per-line": [2, 1],
+    "react/jsx-max-props-per-line": [2, {"maximum" : 1}],
     "react/jsx-no-bind": 2,
     "react/jsx-no-duplicate-props": 2,
     "react/jsx-no-literals": 0,


### PR DESCRIPTION
Was blowing up my editor ESLint. Formatting dictates that the maximum should be an object:

https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-max-props-per-line.md
