### PR TITLE
Replace "space-after-keywords" with "keyword-spacing"

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -53,7 +53,7 @@
     "valid-typeof": 2,
     "wrap-iife": [2, "inside"],
     "no-use-before-define": [2, "nofunc"],
-    "space-after-keywords": 2,
+    "keyword-spacing": 2,
     "brace-style": [2, "1tbs"],
     "consistent-this": [1, "that"],
     "eol-last": 1,


### PR DESCRIPTION
`space-after-keywords` was deprecated in ESLint 2.0:
http://eslint.org/docs/rules/space-after-keywords
