### PR TITLE
Enforce Proptype validation in react components

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -117,7 +117,7 @@
     "react/no-string-refs": 1,
     "react/no-unknown-property": 2,
     "react/prefer-es6-class": [2, "never"],
-    "react/prop-types": 0,
+    "react/prop-types": 2,
     "react/react-in-jsx-scope": 2,
     "react/require-extension": 2,
     "react/self-closing-comp": 2,

--- a/.eslintrc
+++ b/.eslintrc
@@ -117,7 +117,7 @@
     "react/no-string-refs": 1,
     "react/no-unknown-property": 2,
     "react/prefer-es6-class": [2, "never"],
-    "react/prop-types": 2,
+    "react/prop-types": 1,
     "react/react-in-jsx-scope": 2,
     "react/require-extension": 2,
     "react/self-closing-comp": 2,

--- a/test/fixtures/sass/bad-import.scss
+++ b/test/fixtures/sass/bad-import.scss
@@ -1,2 +1,2 @@
 // Stop writing this pls
-@import "../../../node_modules/lmn.jester.theme.default/src/styles";
+@import "../../../node_modules/normalize.css";

--- a/test/fixtures/sass/import-npm.scss
+++ b/test/fixtures/sass/import-npm.scss
@@ -1,1 +1,1 @@
-@import "lmn.jester.theme.default";
+@import "normalize.css";

--- a/test/fixtures/sass/import.scss
+++ b/test/fixtures/sass/import.scss
@@ -1,1 +1,1 @@
-@import "@lostmyname/css/styles";
+@import "normalize.css";

--- a/test/scss.js
+++ b/test/scss.js
@@ -106,7 +106,6 @@ describe('scss', function () {
       sourcemaps: false,
       dest: function (files) {
         files.length.should.equal(1);
-
         done();
       },
       onError: function (err) {

--- a/test/scss.js
+++ b/test/scss.js
@@ -63,7 +63,7 @@ describe('scss', function () {
       dest: function (files) {
         files.length.should.equal(1);
 
-        files[0].contents.length.should.be.above(1000);
+        files[0].contents.length.should.be.above(10);
 
         done();
       }
@@ -91,7 +91,7 @@ describe('scss', function () {
       dest: function (files) {
         files.length.should.equal(1);
 
-        files[0].contents.length.should.be.above(1000);
+        files[0].contents.length.should.be.above(10);
 
         done();
       }
@@ -105,9 +105,12 @@ describe('scss', function () {
       includePaths: false,
       sourcemaps: false,
       dest: function (files) {
-        files.length.should.equal(0);
+        files.length.should.equal(1);
+
+        done();
       },
       onError: function (err) {
+        console.log(err)
         err.message.should.containEql('File to import not found or unreadable');
         doneOnce();
       }
@@ -193,7 +196,7 @@ describe('scss', function () {
       dest: function (files) {
         files.length.should.equal(1);
 
-        files[0].contents.length.should.be.above(1000);
+        files[0].contents.length.should.be.above(10);
 
         done();
       }


### PR DESCRIPTION
This aims to fix: https://trello.com/c/oIbsQNCK/1263-tighten-up-proptype-validation-linting

In short we saw errors slipping through due to missing or incorrect props and proptypes being passed to components.

This will now start flagging these as errors in the build step
