### PR TITLE
Update gulp-svg2png to fix Sierra

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "gulp-sass": "^2.3.2",
     "gulp-sourcemaps": "^1.6.0",
     "gulp-strip-debug": "^1.1.0",
-    "gulp-svg2png": "^1.0.2",
+    "gulp-svg2png": "^2.0.2",
     "gulp-uglify": "^1.5.3",
     "gulp-util": "^3.0.2",
     "gulp.spritesmith": "^4.3.0",


### PR DESCRIPTION
This updates to the latest version of gulp-svg2png which works on macOS Sierra
