### PR TITLE
Add paths support

### DIFF
--- a/tasks/browserify.js
+++ b/tasks/browserify.js
@@ -41,6 +41,10 @@ module.exports = function (vinyl, plugins, options) {
       opts = _.assign({}, watchify.args, opts);
     }
 
+    if (options.paths) {
+      opts.paths = options.paths;
+    }
+
     var bundler = browserify(opts);
 
     if (options.watch) {


### PR DESCRIPTION
This gives us the ability to support the `paths` feature of browserify which allows us to do really nice things such as:

```javascript
var jsOpts = {
  src: './src/js/script.js',
  dest: path.join(buildPath, 'js/bundle.min.js'),
  react: true,
  resolvePath: resolvePath,
  jquery: false,
  paths: ['./src/helpers']
};
```

which then in tern allow us to do the following:

```javascript
// src/js/partials/Footer/Footer.js

// bad horrible
import { helperName } from '../../../helpers/helperFile';

// yayyyy
import { helperName } from 'helperFile';
```